### PR TITLE
#14, #34 전체 Member 리스트 구현 

### DIFF
--- a/src/Assets/MOCK_DATA.js
+++ b/src/Assets/MOCK_DATA.js
@@ -4,7 +4,7 @@ const user = [
     nickname: 'apple',
     email: 'apple@naver.com',
     status: 'online',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room1',
   },
   {
@@ -12,7 +12,7 @@ const user = [
     nickname: 'banana',
     email: 'banana@naver.com',
     status: 'offline',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room2',
   },
   {
@@ -20,7 +20,7 @@ const user = [
     nickname: 'melon',
     email: 'melon@naver.com',
     status: 'online',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room3',
   },
   {
@@ -28,7 +28,7 @@ const user = [
     nickname: 'orange',
     email: 'orange@naver.com',
     status: 'online',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room4',
   },
   {
@@ -36,7 +36,7 @@ const user = [
     nickname: 'mango',
     email: 'mango@naver.com',
     status: 'offline',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room5',
   },
   {
@@ -44,7 +44,7 @@ const user = [
     nickname: 'tomato',
     email: 'tomato@naver.com',
     status: 'offline',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room6',
   },
   {
@@ -52,7 +52,7 @@ const user = [
     nickname: 'coke',
     email: 'coke@naver.com',
     status: 'online',
-    thumbnail: 'https://getuikit.com/v2/docs/images/placeholder_600x400.svg',
+    thumbnail: 'https://avatars.githubusercontent.com/u/66353903?v=4',
     room: 'room7',
   },
 ];

--- a/src/Components/ChatPannel/SidePannel/MemberList.tsx
+++ b/src/Components/ChatPannel/SidePannel/MemberList.tsx
@@ -1,7 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { FaCaretRight } from 'react-icons/fa';
+import {
+  collection,
+  onSnapshot,
+  query,
+} from 'firebase/firestore';
+import { db } from 'fBase';
+
+import { style } from './MemberListStyle';
 
 const MemberList = () => {
-  return <div></div>;
+  const [memberList, setMemberList] = useState<any[]>([]);
+
+  const memberListListener = () => {
+    const q = query(collection(db, 'users'));
+    onSnapshot(q, (doc) => {
+      const temp: any[] = [];
+      doc.forEach((doc) => {
+        temp.push(doc.data());
+      });
+      setMemberList(temp);
+    });
+  };
+
+  useEffect(() => {
+    memberListListener();
+  }, []);
+
+  return (
+    <Container>
+      <Title>
+        <FaCaretRight />
+        <h6>All Member</h6>
+      </Title>
+      <MemberLists>
+        {memberList.map((data, idx) => (
+          <li key={idx}>
+            <img
+              src="https://avatars.githubusercontent.com/u/66353903?v=4"
+              alt="members"
+            />
+            {data.nickname}
+          </li>
+        ))}
+      </MemberLists>
+    </Container>
+  );
 };
 
 export default MemberList;
+
+const { Container, Title, MemberLists } = style;

--- a/src/Components/ChatPannel/SidePannel/MemberListStyle.ts
+++ b/src/Components/ChatPannel/SidePannel/MemberListStyle.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Title = styled.div`
+  height: 49px;
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+  border-left: 1px solid rgba(29, 28, 29, 0.13);
+  border-bottom: 1px solid rgba(29, 28, 29, 0.13);
+  background: #fceb92;
+
+  h6 {
+    font-size: 16px;
+    font-weight: 600;
+  }
+`;
+
+const MemberLists = styled.ul`
+  padding: 20px;
+
+  img {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    margin-right: 5px;
+    vertical-align: middle;
+  }
+  li {
+    margin-bottom: 15px;
+    font-size: 16px;
+    font-weight: 500;
+    color: #333;
+  }
+`;
+
+export const style = { Container, Title, MemberLists };

--- a/src/Pages/Chat/ChatPage.tsx
+++ b/src/Pages/Chat/ChatPage.tsx
@@ -1,4 +1,6 @@
 import { MainPannel, HeaderPannel, SidePannel } from 'Components';
+import MemberList from 'Components/ChatPannel/SidePannel/MemberList';
+
 import React from 'react';
 const ChatPage: React.FC = () => {
   return (
@@ -7,6 +9,7 @@ const ChatPage: React.FC = () => {
       <div style={{ display: 'flex' }}>
         <SidePannel />
         <MainPannel />
+        <MemberList />
       </div>
     </>
   );

--- a/src/fBase.js
+++ b/src/fBase.js
@@ -16,4 +16,3 @@ const firebaseConfig = {
 export const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const storage = getStorage();
-// 'gs://chatpong-42469.appspot.com'

--- a/src/fBase.js
+++ b/src/fBase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_API_KEY,
@@ -13,4 +14,6 @@ const firebaseConfig = {
 
 // Initialize Firebase
 export const app = initializeApp(firebaseConfig);
-export const db = getFirestore();
+export const db = getFirestore(app);
+export const storage = getStorage();
+// 'gs://chatpong-42469.appspot.com'


### PR DESCRIPTION
# PR 제목
전체 Member 리스트 구현 
<br/>

## 해당 이슈 📎

#14 
#34 

## 변경 사항 🛠

![image](https://user-images.githubusercontent.com/51367622/135406202-832a7707-3a52-4cb5-9311-53378be41bf2.png)

- 전체 MemberList UI 구현 .
- Firestore에 저장되어 있는 User 읽기.

<br/>

## 리뷰어 참고 사항 🙋‍♀️

> 없음.