### PR TITLE
#14 Follow List UI 구현

### DIFF
--- a/src/Components/ChatPannel/SidePannel/FollowList/FollowList.tsx
+++ b/src/Components/ChatPannel/SidePannel/FollowList/FollowList.tsx
@@ -16,10 +16,21 @@ const FollowList = () => {
       </Title>
       <MemberLists>
         {memberList.map((data, idx) => (
-          <li key={idx}>
-            <img src={data.photoURL} alt="members" />
-            {data.nickname}
-          </li>
+          <div>
+            <li key={idx}>
+              <img src={data.photoURL} alt="members" />
+              {data.nickname}
+            </li>
+            <button
+              style={{
+                background: 'transparent',
+                color: '#611f66',
+                border: '1px solid #611f66',
+              }}
+            >
+              언팔로우
+            </button>
+          </div>
         ))}
       </MemberLists>
     </Container>

--- a/src/Components/ChatPannel/SidePannel/FollowList/FollowList.tsx
+++ b/src/Components/ChatPannel/SidePannel/FollowList/FollowList.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FaCaretRight } from 'react-icons/fa';
+import { MlStyle } from '../MemberList/MemberListStyle';
+import { useRecoilState } from 'recoil';
+import { atomMemberList } from 'Recoil/atom';
+
+const FollowList = () => {
+  const [memberList, setMemberList] = useRecoilState(atomMemberList);
+  return (
+    <Container>
+      <Title>
+        <div>
+          <FaCaretRight />
+        </div>
+        <h6>Follow List</h6>
+      </Title>
+      <MemberLists>
+        {memberList.map((data, idx) => (
+          <li key={idx}>
+            <img src={data.photoURL} alt="members" />
+            {data.nickname}
+          </li>
+        ))}
+      </MemberLists>
+    </Container>
+  );
+};
+
+export default FollowList;
+
+const { Container, Title, MemberLists } = MlStyle;

--- a/src/Components/ChatPannel/SidePannel/MemberList/MemberList.tsx
+++ b/src/Components/ChatPannel/SidePannel/MemberList/MemberList.tsx
@@ -46,15 +46,18 @@ const MemberList = () => {
       </Title>
       <MemberLists>
         {memberList.map((data, idx) => (
-          <li
-            key={idx}
-            onClick={() => {
-              handleClickedUser(data);
-            }}
-          >
-            <img src={data.photoURL} alt="members" />
-            {data.nickname}
-          </li>
+          <div>
+            <li
+              key={idx}
+              onClick={() => {
+                handleClickedUser(data);
+              }}
+            >
+              <img src={data.photoURL} alt="members" />
+              {data.nickname}
+            </li>
+            <button>팔로우</button>
+          </div>
         ))}
       </MemberLists>
     </Container>

--- a/src/Components/ChatPannel/SidePannel/MemberList/MemberList.tsx
+++ b/src/Components/ChatPannel/SidePannel/MemberList/MemberList.tsx
@@ -52,10 +52,7 @@ const MemberList = () => {
               handleClickedUser(data);
             }}
           >
-            <img
-              src="https://avatars.githubusercontent.com/u/66353903?v=4"
-              alt="members"
-            />
+            <img src={data.photoURL} alt="members" />
             {data.nickname}
           </li>
         ))}

--- a/src/Components/ChatPannel/SidePannel/MemberList/MemberListStyle.ts
+++ b/src/Components/ChatPannel/SidePannel/MemberList/MemberListStyle.ts
@@ -29,6 +29,15 @@ const Title = styled.div`
 const MemberLists = styled.ul`
   padding: 20px;
 
+  div {
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-direction: row;
+    margin-bottom: 15px;
+  }
+
   img {
     width: 36px;
     height: 36px;
@@ -36,12 +45,22 @@ const MemberLists = styled.ul`
     margin-right: 5px;
     vertical-align: middle;
   }
+
   li {
-    margin-bottom: 15px;
     font-size: 16px;
     font-weight: 500;
     color: #333;
     cursor: pointer;
+  }
+
+  button {
+    height: 26px;
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    border: 0;
+    background: #611f66;
+    color: #fff;
   }
 `;
 

--- a/src/Components/ChatPannel/SidePannel/MemberList/MemberListStyle.ts
+++ b/src/Components/ChatPannel/SidePannel/MemberList/MemberListStyle.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 300px;
+  height: 50%;
   display: flex;
   flex-direction: column;
   border-left: 1px solid rgba(29, 28, 29, 0.13);

--- a/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
+++ b/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
@@ -12,12 +12,12 @@ import {
   getStorage,
   uploadBytesResumable,
 } from '@firebase/storage';
-import { doc, updateDoc, setDoc } from 'firebase/firestore';
+import { doc, updateDoc } from 'firebase/firestore';
 import { db } from 'fBase';
 import { TextInputProps } from 'Types/TextInputProps';
 
 const Profile = ({ init }: TextInputProps) => {
-  const [text, setText] = useState(' ');
+  const [text, setText] = useState(init);
   const [editable, setEditable] = useState(false);
   const auth = getAuth();
   const history = useHistory();
@@ -77,12 +77,6 @@ const Profile = ({ init }: TextInputProps) => {
     setText(e.target.value);
   };
 
-  // const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-  //   if (e.key === 'Enter') {
-  //     setEditable(!editable);
-  //   }
-  // };
-
   const handleUpdateNickname = async () => {
     const editName = doc(db, 'users', `${clickedUserInfo.uid}`);
     if (auth.currentUser) {
@@ -95,7 +89,6 @@ const Profile = ({ init }: TextInputProps) => {
     });
     setEditable(!editable);
   };
-  console.log(auth.currentUser?.displayName);
 
   return (
     <Container>
@@ -125,7 +118,6 @@ const Profile = ({ init }: TextInputProps) => {
                 type="text"
                 value={text}
                 onChange={(e) => handleChange(e)}
-                // onKeyDown={handleKeyDown}
                 placeholder="변경할 닉네임을 입력하세요."
               />
               <button onClick={handleUpdateNickname}>변경</button>

--- a/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
+++ b/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { atomClickedUser, atomMyInfo } from 'Recoil/atom';
 import { getAuth, signOut, updateProfile } from '@firebase/auth';
-import { FaTimes, FaPaperPlane, FaEdit } from 'react-icons/fa';
+import { FaTimes, FaPaperPlane, FaEdit, FaUserPlus } from 'react-icons/fa';
 import { style } from './ProfileStyle';
 import { MlStyle } from 'Components/ChatPannel/SidePannel/MemberList/MemberListStyle';
 import {
@@ -98,12 +98,20 @@ const Profile = () => {
             </BtnIcon>
             <span>Direct Message</span>
           </Btn>
+          {myInfo.uid !== clickedUserInfo.uid && (
+            <Btn>
+              <BtnIcon>
+                <FaUserPlus />
+              </BtnIcon>
+              <span>친구 추가</span>
+            </Btn>
+          )}
           {myInfo.uid === clickedUserInfo.uid && (
             <Btn>
               <BtnIcon>
                 <FaEdit />
               </BtnIcon>
-              <span>Edit Profile</span>
+              <span>닉네임 변경</span>
             </Btn>
           )}
         </BtnGroup>

--- a/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
+++ b/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
@@ -12,12 +12,12 @@ import {
   getStorage,
   uploadBytesResumable,
 } from '@firebase/storage';
-import { doc, updateDoc } from 'firebase/firestore';
+import { doc, updateDoc, setDoc } from 'firebase/firestore';
 import { db } from 'fBase';
 import { TextInputProps } from 'Types/TextInputProps';
 
 const Profile = ({ init }: TextInputProps) => {
-  const [text, setText] = useState(init);
+  const [text, setText] = useState(' ');
   const [editable, setEditable] = useState(false);
   const auth = getAuth();
   const history = useHistory();
@@ -47,7 +47,7 @@ const Profile = ({ init }: TextInputProps) => {
     const metadata = {
       contentType: 'image/jpeg',
     };
-    const docRef = doc(db, 'users', `${clickedUserInfo.nickname}`);
+    const docRef = doc(db, 'users', `${clickedUserInfo.uid}`);
     uploadBytesResumable(imageRef, file, metadata)
       .then((snapshot) => {
         getDownloadURL(snapshot.ref).then((url) => {
@@ -77,20 +77,25 @@ const Profile = ({ init }: TextInputProps) => {
     setText(e.target.value);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const editName = doc(db, 'users', `${clickedUserInfo.nickname}`);
-    if (e.key === 'Enter') {
-      setEditable(!editable);
-    } else if (auth.currentUser) {
+  // const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  //   if (e.key === 'Enter') {
+  //     setEditable(!editable);
+  //   }
+  // };
+
+  const handleUpdateNickname = async () => {
+    const editName = doc(db, 'users', `${clickedUserInfo.uid}`);
+    if (auth.currentUser) {
       updateProfile(auth.currentUser, {
         displayName: text,
       });
     }
-    updateDoc(editName, {
+    await updateDoc(editName, {
       nickname: text,
     });
-    console.log(auth.currentUser);
+    setEditable(!editable);
   };
+  console.log(auth.currentUser?.displayName);
 
   return (
     <Container>
@@ -115,13 +120,16 @@ const Profile = ({ init }: TextInputProps) => {
         />
         <UserInfo>
           {editable ? (
-            <input
-              type="text"
-              value={text}
-              onChange={(e) => handleChange(e)}
-              onKeyDown={handleKeyDown}
-              placeholder="변경할 닉네임을 입력하세요."
-            />
+            <div>
+              <input
+                type="text"
+                value={text}
+                onChange={(e) => handleChange(e)}
+                // onKeyDown={handleKeyDown}
+                placeholder="변경할 닉네임을 입력하세요."
+              />
+              <button onClick={handleUpdateNickname}>변경</button>
+            </div>
           ) : (
             <UserName>{clickedUserInfo.nickname}</UserName>
           )}

--- a/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
+++ b/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
@@ -120,6 +120,7 @@ const Profile = ({ init }: TextInputProps) => {
               value={text}
               onChange={(e) => handleChange(e)}
               onKeyDown={handleKeyDown}
+              placeholder="변경할 닉네임을 입력하세요."
             />
           ) : (
             <UserName>{clickedUserInfo.nickname}</UserName>

--- a/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
+++ b/src/Components/ChatPannel/SidePannel/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { ReactEventHandler, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { atomClickedUser, atomMyInfo } from 'Recoil/atom';
@@ -14,8 +14,11 @@ import {
 } from '@firebase/storage';
 import { doc, updateDoc } from 'firebase/firestore';
 import { db } from 'fBase';
+import { TextInputProps } from 'Types/TextInputProps';
 
-const Profile = () => {
+const Profile = ({ init }: TextInputProps) => {
+  const [text, setText] = useState(init);
+  const [editable, setEditable] = useState(false);
   const auth = getAuth();
   const history = useHistory();
   const resetClickedUser = useResetRecoilState(atomClickedUser);
@@ -66,6 +69,20 @@ const Profile = () => {
       });
   };
 
+  const editOn = () => {
+    setEditable(true);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setEditable(!editable);
+    }
+  };
+
   return (
     <Container>
       <ProfileTitle>
@@ -88,7 +105,16 @@ const Profile = () => {
           ref={inputOpenImageRef}
         />
         <UserInfo>
-          <UserName>{clickedUserInfo.nickname}</UserName>
+          {editable ? (
+            <input
+              type="text"
+              value={text}
+              onChange={(e) => handleChange(e)}
+              onKeyDown={handleKeyDown}
+            />
+          ) : (
+            <UserName>{clickedUserInfo.nickname}</UserName>
+          )}
           <UserEmail>{clickedUserInfo.email}</UserEmail>
         </UserInfo>
         <BtnGroup>
@@ -107,7 +133,7 @@ const Profile = () => {
             </Btn>
           )}
           {myInfo.uid === clickedUserInfo.uid && (
-            <Btn>
+            <Btn onClick={() => editOn()}>
               <BtnIcon>
                 <FaEdit />
               </BtnIcon>

--- a/src/Components/ChatPannel/SidePannel/Profile/ProfileStyle.ts
+++ b/src/Components/ChatPannel/SidePannel/Profile/ProfileStyle.ts
@@ -29,9 +29,32 @@ const UserInfo = styled.div`
   padding: 10px 20px;
   text-align: center;
 
+  div {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 20px;
+  }
+
   input {
+    width: 200px;
     height: 30px;
-    margin-bottom: 10px;
+    margin-right: 5px;
+  }
+
+  button {
+    width: 50px;
+    height: 36px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 0;
+    background: #611f66;
+    color: #fff;
+    transition: 0.5s;
+
+    &:hover {
+      font-weight: 600;
+    }
   }
 `;
 

--- a/src/Components/ChatPannel/SidePannel/Profile/ProfileStyle.ts
+++ b/src/Components/ChatPannel/SidePannel/Profile/ProfileStyle.ts
@@ -28,6 +28,11 @@ const UserInfo = styled.div`
   flex-direction: column;
   padding: 10px 20px;
   text-align: center;
+
+  input {
+    height: 30px;
+    margin-bottom: 10px;
+  }
 `;
 
 const UserName = styled.h6`

--- a/src/Components/ChatPannel/SidePannel/index.ts
+++ b/src/Components/ChatPannel/SidePannel/index.ts
@@ -4,3 +4,4 @@ export { default as FriendsList } from './FriendsList/FriendsList';
 export { default as MemberList } from './MemberList/MemberList';
 export { default as Profile } from './Profile/Profile';
 export { default as SidePannel } from './SidePannel/SidePannel';
+export { default as FollowList } from './FollowList/FollowList';

--- a/src/Pages/Chat/ChatPage.tsx
+++ b/src/Pages/Chat/ChatPage.tsx
@@ -7,8 +7,9 @@ import { atomClickedUser, atomMyInfo } from 'Recoil/atom';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from 'fBase';
+import { TextInputProps } from 'Types/TextInputProps';
 
-const ChatPage: React.FC = () => {
+const ChatPage: React.FC<TextInputProps> = ({ init }) => {
   const clickedUser = useRecoilValue(atomClickedUser);
   const setMyInfo = useSetRecoilState(atomMyInfo);
   const myInfoReset = useResetRecoilState(atomMyInfo);
@@ -40,7 +41,7 @@ const ChatPage: React.FC = () => {
       <div style={{ display: 'flex' }}>
         <SidePannel />
         <MainPannel />
-        {!clickedUser.uid ? <MemberList /> : <Profile />}
+        {!clickedUser.uid ? <MemberList /> : <Profile init={init} />}
       </div>
     </>
   );

--- a/src/Pages/Chat/ChatPage.tsx
+++ b/src/Pages/Chat/ChatPage.tsx
@@ -1,13 +1,18 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { MainPannel, HeaderPannel, SidePannel } from 'Components';
-import { MemberList, Profile } from 'Components/ChatPannel/SidePannel';
+import {
+  FollowList,
+  MemberList,
+  Profile,
+} from 'Components/ChatPannel/SidePannel';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { atomClickedUser, atomMyInfo } from 'Recoil/atom';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from 'fBase';
 import { TextInputProps } from 'Types/TextInputProps';
+import { Style } from './ChatPageStyle';
 
 const ChatPage: React.FC<TextInputProps> = ({ init }) => {
   const clickedUser = useRecoilValue(atomClickedUser);
@@ -41,10 +46,19 @@ const ChatPage: React.FC<TextInputProps> = ({ init }) => {
       <div style={{ display: 'flex' }}>
         <SidePannel />
         <MainPannel />
-        {!clickedUser.uid ? <MemberList /> : <Profile init={init} />}
+        {!clickedUser.uid ? (
+          <ListPannel>
+            <MemberList />
+            <FollowList />
+          </ListPannel>
+        ) : (
+          <Profile init={init} />
+        )}
       </div>
     </>
   );
 };
 
 export default ChatPage;
+
+const { ListPannel } = Style;

--- a/src/Pages/Chat/ChatPageStyle.ts
+++ b/src/Pages/Chat/ChatPageStyle.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+const ListPannel = styled.div``;
+
+export const Style = { ListPannel };

--- a/src/Pages/SignUp/SignUp.tsx
+++ b/src/Pages/SignUp/SignUp.tsx
@@ -39,8 +39,7 @@ const SignUp: React.FC = () => {
           photoURL:
             'https://iupac.org/wp-content/uploads/2018/05/default-avatar.png',
         });
-        console.log(auth.currentUser.displayName, auth.currentUser.photoURL);
-        await setDoc(doc(db, 'users', `${data.nickname}`), {
+        await setDoc(doc(db, 'users', `${auth.currentUser.uid}`), {
           nickname: data.nickname,
           email: data.email,
           uid: auth.currentUser.uid,
@@ -162,12 +161,6 @@ const {
   Form,
   Wrap,
   FormLabel,
-  Horizontal,
-  Hr,
-  Input,
-  SignUpText,
   Strong,
-  Or,
-  ToSignUp,
   TextInput,
 } = style;

--- a/src/Types/TextInputProps.ts
+++ b/src/Types/TextInputProps.ts
@@ -1,0 +1,3 @@
+export interface TextInputProps {
+  init: string;
+}


### PR DESCRIPTION
# PR 제목

<br/>

## 해당 이슈 📎

- #14 
  <br/>

## 변경 사항 🛠

![image](https://user-images.githubusercontent.com/66353903/137337472-de1bb217-7983-46cb-97a2-b886f7dcf85d.png)


- 기존의 친구 리스트를 팔로우로 변경
- 팔로우 리스트 UI 구현
- 프로필 클릭시 멤버 리스트, 팔로우 리스트는 가려지고 프로필 컴포넌트만 출력

<br/>

## 리뷰어 참고 사항 🙋‍♀️

> 현재 팔로우 목록은 전체 멤버 목록을 가져와서 화면에 출력하고 있음
> 팔로우 기능 추가 후 추가된 유저만 가져올 수 있게 수정필요

<br/>

